### PR TITLE
support rsa-sha2-256/512 public key signature digest algorithms

### DIFF
--- a/krd/control_server.go
+++ b/krd/control_server.go
@@ -173,7 +173,7 @@ func (cs *ControlServer) handleEnclaveMe(w http.ResponseWriter, enclaveRequest k
 }
 
 func (cs *ControlServer) handleEnclaveSign(w http.ResponseWriter, enclaveRequest kr.Request) {
-	signResponse, err := cs.enclaveClient.RequestSignature(*enclaveRequest.SignRequest, nil)
+	signResponse, _, err := cs.enclaveClient.RequestSignature(*enclaveRequest.SignRequest, nil)
 	if err != nil {
 		cs.log.Error("signature request error:", err)
 		switch err {

--- a/krd/enclave_client.go
+++ b/krd/enclave_client.go
@@ -367,7 +367,7 @@ func (client *EnclaveClient) RequestSignature(signRequest kr.SignRequest, onACK 
 		client.log.Error(err)
 		return
 	}
-	if callback != nil {
+	if callback != nil && callback.response.SignResponse != nil {
 		response := callback.response
 		signResponse = response.SignResponse
 		enclaveVersion = response.Version

--- a/krd/enclave_client.go
+++ b/krd/enclave_client.go
@@ -11,6 +11,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/blang/semver"
 	"github.com/golang/groupcache/lru"
 	"github.com/kryptco/kr"
 	"github.com/op/go-logging"
@@ -64,7 +65,7 @@ type EnclaveClientI interface {
 	Stop() (err error)
 	RequestMe(isPairing bool) (*kr.MeResponse, error)
 	GetCachedMe() *kr.Profile
-	RequestSignature(kr.SignRequest, func()) (*kr.SignResponse, error)
+	RequestSignature(kr.SignRequest, func()) (*kr.SignResponse, semver.Version, error)
 	RequestNoOp() error
 }
 
@@ -342,7 +343,7 @@ func (client *EnclaveClient) RequestMe(isPairing bool) (meResponse *kr.MeRespons
 	return
 }
 
-func (client *EnclaveClient) RequestSignature(signRequest kr.SignRequest, onACK func()) (signResponse *kr.SignResponse, err error) {
+func (client *EnclaveClient) RequestSignature(signRequest kr.SignRequest, onACK func()) (signResponse *kr.SignResponse, enclaveVersion semver.Version, err error) {
 	start := time.Now()
 	request, err := kr.NewRequest()
 	if err != nil {
@@ -369,6 +370,7 @@ func (client *EnclaveClient) RequestSignature(signRequest kr.SignRequest, onACK 
 	if callback != nil {
 		response := callback.response
 		signResponse = response.SignResponse
+		enclaveVersion = response.Version
 		millis := uint64(time.Since(start) / time.Millisecond)
 		client.log.Notice("Signature response took", millis, "ms")
 		client.postEvent("signature", "success", &callback.medium, &millis)

--- a/krd/enclave_client_test.go
+++ b/krd/enclave_client_test.go
@@ -151,7 +151,7 @@ func testSignature(t *testing.T, ec EnclaveClientI) (resp *kr.SignResponse, dige
 
 	me, _, _ := kr.TestMe(t)
 	fp := me.PublicKeyFingerprint()
-	signResponse, err := ec.RequestSignature(kr.SignRequest{
+	signResponse, _, err := ec.RequestSignature(kr.SignRequest{
 		PublicKeyFingerprint: fp[:],
 		Data:                 digest[:],
 	},

--- a/krd/host_validation.go
+++ b/krd/host_validation.go
@@ -1,8 +1,6 @@
 package krd
 
-import (
-	"golang.org/x/crypto/ssh"
-)
+import "golang.org/x/crypto/ssh"
 
 //	from https://github.com/golang/crypto/blob/master/ssh/common.go#L243-L264
 type signaturePayload struct {
@@ -48,12 +46,15 @@ func stripPubkeyFromSignaturePayload(data []byte) (stripped []byte, err error) {
 	return
 }
 
-func parseSessionFromSignaturePayload(data []byte) (session []byte, err error) {
+func parseSessionAndAlgoFromSignaturePayload(data []byte) (session []byte, algo string, err error) {
 	signedDataFormat := signaturePayload{}
 	err = ssh.Unmarshal(data, &signedDataFormat)
 	if err != nil {
 		return
 	}
+
 	session = signedDataFormat.Session
+	algo = string(signedDataFormat.Algo)
+
 	return
 }

--- a/krd/ssh_agent.go
+++ b/krd/ssh_agent.go
@@ -431,8 +431,10 @@ func ServeKRAgent(enclaveClient EnclaveClientI, agentListener net.Listener, host
 			continue
 		}
 		go func() {
-			defer conn.Close()
-			agent.ServeAgent(krAgent, conn)
+			kr.RecoverToLog(func() {
+				defer conn.Close()
+				agent.ServeAgent(krAgent, conn)
+			}, log)
 		}()
 	}
 }

--- a/krd/ssh_agent.go
+++ b/krd/ssh_agent.go
@@ -118,7 +118,10 @@ func (a *Agent) Sign(key ssh.PublicKey, data []byte) (sshSignature *ssh.Signatur
 		return
 	}
 
-	session, err := parseSessionFromSignaturePayload(data)
+	session, algo, err := parseSessionAndAlgoFromSignaturePayload(data)
+
+	a.log.Notice("Using Public Key Signature Digest Algorithm: " + algo)
+
 	var hostAuth *kr.HostAuth
 	notifyPrefix := ""
 	if err != nil {
@@ -203,7 +206,7 @@ func (a *Agent) Sign(key ssh.PublicKey, data []byte) (sshSignature *ssh.Signatur
 	a.notify(notifyPrefix, notifyPrefix+kr.Green("Kryptonite ▶ Success. Request Allowed ✔"))
 	signature := *signResponse.Signature
 	sshSignature = &ssh.Signature{
-		Format: key.Type(),
+		Format: algo,
 		Blob:   signature,
 	}
 	if notifyPrefix != "" {

--- a/protocol.go
+++ b/protocol.go
@@ -9,6 +9,9 @@ import (
 	"github.com/blang/semver"
 )
 
+//	Previous enclave versions assume SHA1 for all RSA keys regardless of the PubKeyAlgorithm specified in the signature payload
+var ENCLAVE_VERSION_SUPPORTS_RSA_SHA2_256_512 = semver.MustParse("2.1.0")
+
 type Request struct {
 	RequestID     string         `json:"request_id"`
 	UnixSeconds   int64          `json:"unix_seconds"`

--- a/version_darwin.go
+++ b/version_darwin.go
@@ -4,7 +4,7 @@ import (
 	"github.com/blang/semver"
 )
 
-var CURRENT_VERSION = semver.MustParse("2.0.5")
+var CURRENT_VERSION = semver.MustParse("2.1.0")
 
 func GetLatestVersion() (version semver.Version, err error) {
 	versions, err := GetLatestVersions()

--- a/version_linux.go
+++ b/version_linux.go
@@ -4,7 +4,7 @@ import (
 	"github.com/blang/semver"
 )
 
-var CURRENT_VERSION = semver.MustParse("2.0.5")
+var CURRENT_VERSION = semver.MustParse("2.1.0")
 
 func GetLatestVersion() (version semver.Version, err error) {
 	versions, err := GetLatestVersions()


### PR DESCRIPTION
Support for rsa-sha2-256, rsa-sha-512 client signature digests. Referenced in https://tools.ietf.org/html/draft-rsa-dsa-sha2-256-03.