### PR TITLE
using net.JoinHostPost to support connecting to bare ip6 addresses

### DIFF
--- a/krssh/krssh.go
+++ b/krssh/krssh.go
@@ -258,7 +258,7 @@ func main() {
 		}
 
 		var err error
-		remoteConn, err = net.Dial("tcp", host+":"+port)
+		remoteConn, err = net.Dial("tcp", net.JoinHostPort(host,port))
 		if err != nil {
 			fatal(kr.Red("could not connect to remote: " + err.Error()))
 		}


### PR DESCRIPTION
Hi!

I've patched krssh to wrap host+post using net.JoinHostPort. This allows ssh'ing to bare ip6 addresses as net.Dial requires them to be in [addr]:port format which net.JoinHostPort takes care of.