### PR TITLE
Add --name option to 'kr pair'.  Allows user to set the WorkstationName

### DIFF
--- a/kr/kr_test.go
+++ b/kr/kr_test.go
@@ -20,7 +20,7 @@ func TestPair(t *testing.T) {
 func testPairSuccess(t *testing.T, unixFile string, ec krd.EnclaveClientI) {
 	stdout := &bytes.Buffer{}
 	stderr := &bytes.Buffer{}
-	err := pairOver(unixFile, true, stdout, stderr)
+	err := pairOver(unixFile, true, "", stdout, stderr)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/krd/control_server.go
+++ b/krd/control_server.go
@@ -98,7 +98,14 @@ func (cs *ControlServer) handleGetPair(w http.ResponseWriter, r *http.Request) {
 
 //	initiate new pairing (clearing any existing)
 func (cs *ControlServer) handlePutPair(w http.ResponseWriter, r *http.Request) {
-	pairingSecret, err := cs.enclaveClient.Pair()
+	var paringOptions kr.PairingOptions
+	err := json.NewDecoder(r.Body).Decode(&paringOptions)
+	if err != nil {
+		w.WriteHeader(http.StatusBadRequest)
+		return
+	}
+
+	pairingSecret, err := cs.enclaveClient.Pair(paringOptions)
 	if err != nil {
 		w.WriteHeader(http.StatusInternalServerError)
 		w.Write([]byte(err.Error()))

--- a/krd/control_server_test.go
+++ b/krd/control_server_test.go
@@ -6,9 +6,11 @@ import (
 	"net/http/httptest"
 	"testing"
 	"time"
+	"bytes"
 
 	"github.com/kryptco/kr"
 	"github.com/op/go-logging"
+	"bytes"
 )
 
 func NewTestControlServer(ec EnclaveClientI) *ControlServer {
@@ -19,7 +21,14 @@ func TestControlServerPair(t *testing.T) {
 	transport := &kr.ResponseTransport{T: t}
 	ec := NewTestEnclaveClient(transport)
 	cs := NewTestControlServer(ec)
-	pairRequest, err := http.NewRequest("PUT", "/pair", nil)
+
+	var pairingOptions kr.PairingOptions
+	var body, err = json.Marshal(pairingOptions)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	pairRequest, err := http.NewRequest("PUT", "/pair", bytes.NewBuffer(body))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -35,7 +44,7 @@ func TestControlServerPair(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	getPairRequest, err := http.NewRequest("GET", "/pair", nil)
+	getPairRequest, err := http.NewRequest("GET", "/pair", bytes.NewBuffer(body))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -60,7 +69,14 @@ func TestControlServerUnpair(t *testing.T) {
 	transport := &kr.ResponseTransport{T: t}
 	ec := NewTestEnclaveClientShortTimeouts(transport)
 	cs := NewTestControlServer(ec)
-	pairRequest, err := http.NewRequest("PUT", "/pair", nil)
+	var pairingOptions kr.PairingOptions
+
+	var body, err = json.Marshal(pairingOptions)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	pairRequest, err := http.NewRequest("PUT", "/pair", bytes.NewBuffer(body))
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/krd/enclave_client.go
+++ b/krd/enclave_client.go
@@ -58,7 +58,7 @@ func (err *ProtoError) Error() string {
 
 type EnclaveClientI interface {
 	kr.Transport
-	Pair() (pairing *kr.PairingSecret, err error)
+	Pair(kr.PairingOptions) (pairing *kr.PairingSecret, err error)
 	IsPaired() bool
 	Unpair()
 	Start() (err error)
@@ -89,11 +89,11 @@ type EnclaveClient struct {
 const BLUETOOTH = "bluetooth"
 const SQS = "sqs"
 
-func (ec *EnclaveClient) Pair() (pairingSecret *kr.PairingSecret, err error) {
+func (ec *EnclaveClient) Pair(pairingOptions kr.PairingOptions) (pairingSecret *kr.PairingSecret, err error) {
 	ec.Lock()
 	defer ec.Unlock()
 
-	err = ec.generatePairing()
+	err = ec.generatePairing(pairingOptions)
 	if err != nil {
 		return
 	}
@@ -124,14 +124,14 @@ func (ec *EnclaveClient) IsPaired() bool {
 	return ps.IsPaired()
 }
 
-func (ec *EnclaveClient) generatePairing() (err error) {
+func (ec *EnclaveClient) generatePairing(pairingOptions kr.PairingOptions) (err error) {
 	if ec.pairingSecret != nil {
 		ec.unpair(ec.pairingSecret, true)
 	}
 	ec.Persister.DeleteMe()
 	ec.Persister.DeletePairing()
 
-	pairingSecret, err := kr.GeneratePairingSecret()
+	pairingSecret, err := kr.GeneratePairingSecret(pairingOptions.WorkstationName)
 	if err != nil {
 		ec.log.Error(err)
 		return

--- a/krd/enclave_client_test_util.go
+++ b/krd/enclave_client_test_util.go
@@ -77,7 +77,8 @@ func PairClient(t *testing.T, client EnclaveClientI) (ps *kr.PairingSecret) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	ps, err = client.Pair()
+	var pairingOptions kr.PairingOptions
+	ps, err = client.Pair(pairingOptions)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/pair.go
+++ b/pair.go
@@ -27,6 +27,10 @@ type PairingSecret struct {
 	sync.Mutex
 }
 
+type PairingOptions struct{
+	WorkstationName string `json:"name"`
+}
+
 func (ps *PairingSecret) Equals(other *PairingSecret) bool {
 	return bytes.Equal(ps.WorkstationPublicKey, other.WorkstationPublicKey)
 }
@@ -52,13 +56,17 @@ func (ps *PairingSecret) SQSBaseQueueName() string {
 	return strings.ToUpper(derivedUUID.String())
 }
 
-func GeneratePairingSecret() (ps *PairingSecret, err error) {
+func GeneratePairingSecret(workstationName string) (ps *PairingSecret, err error) {
 	ps = new(PairingSecret)
 	ps.WorkstationPublicKey, ps.workstationSecretKey, err = GenKeyPair()
 	if err != nil {
 		return
 	}
-	ps.WorkstationName = MachineName()
+	if workstationName == "" {
+		ps.WorkstationName = MachineName()
+	} else {
+		ps.WorkstationName = workstationName
+	}
 	ps.Version = CURRENT_VERSION.String()
 	return
 }

--- a/pair_test.go
+++ b/pair_test.go
@@ -6,9 +6,20 @@ import (
 )
 
 func TestGenWrapEncDec(t *testing.T) {
-	ps, err := GeneratePairingSecret()
+	ps, err := GeneratePairingSecret("test.workstation.name")
 	if err != nil {
 		t.Fatal(err)
+	}
+	if ps.WorkstationName != "test.workstation.name"{
+		t.Fatal("WorkstationName is wrong")
+	}
+
+	ps, err = GeneratePairingSecret("")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if ps.WorkstationName != MachineName(){
+		t.Fatal("WorkstationName is wrong")
 	}
 	sessionKey, err := RandNBytes(32)
 	if err != nil {

--- a/pairing_persistence_test.go
+++ b/pairing_persistence_test.go
@@ -5,7 +5,7 @@ import (
 )
 
 func TestPairingPersistence(t *testing.T) {
-	pairing, err := GeneratePairingSecret()
+	pairing, err := GeneratePairingSecret("")
 	if err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
Common for me to encounter machines where the hostname is set to something like "linux" or "ubuntu".   Therefore to avoid ambiguity of paired machines, this change allow me to set the name to something recognizable.