### PR TITLE
Improve BSD support

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -29,6 +29,9 @@ endif
 ifeq ($(UNAME_S),Darwin)
 	PREFIX ?= /usr/local
 endif
+ifeq ($(UNAME_S),FreeBSD)
+	PREFIX ?= /usr/local
+endif
 
 SRCBIN = $(PWD)/bin
 DSTBIN = $(PREFIX)/bin

--- a/analytics_ua_freebsd.go
+++ b/analytics_ua_freebsd.go
@@ -1,1 +1,32 @@
-analytics_ua_linux.go
+package kr
+
+import (
+	"fmt"
+	"os/exec"
+	"strings"
+	"sync"
+)
+
+var analytics_user_agent = fmt.Sprintf("Mozilla/5.0 (X11; FreeBSD) (KHTML, like Gecko) Version/%s kr/%s", CURRENT_VERSION, CURRENT_VERSION)
+
+const analytics_os = "FreeBSD"
+
+var cachedAnalyticsOSVersion *string
+var osVersionMutex sync.Mutex
+
+func getAnalyticsOSVersion() *string {
+	osVersionMutex.Lock()
+	defer osVersionMutex.Unlock()
+	if cachedAnalyticsOSVersion != nil {
+		return cachedAnalyticsOSVersion
+	}
+
+	analytics_os_version_bytes, err := exec.Command("freebsd-version").Output()
+	if err != nil {
+		log.Error("error retrieving OS version:", err.Error())
+		return nil
+	}
+	stripped := strings.TrimSpace(string(analytics_os_version_bytes))
+	cachedAnalyticsOSVersion = &stripped
+	return cachedAnalyticsOSVersion
+}

--- a/analytics_ua_linux.go
+++ b/analytics_ua_linux.go
@@ -7,7 +7,7 @@ import (
 	"sync"
 )
 
-var analytics_user_agent = fmt.Sprintf("Mozilla/5.0 (Macintosh; Linux) (KHTML, like Gecko) Version/%s kr/%s", CURRENT_VERSION, CURRENT_VERSION)
+var analytics_user_agent = fmt.Sprintf("Mozilla/5.0 (X11; Linux) (KHTML, like Gecko) Version/%s kr/%s", CURRENT_VERSION, CURRENT_VERSION)
 
 const analytics_os = "Linux"
 

--- a/aws_freebsd.go
+++ b/aws_freebsd.go
@@ -1,1 +1,0 @@
-aws_linux.go

--- a/aws_linux.go
+++ b/aws_linux.go
@@ -1,3 +1,0 @@
-package kr
-
-const NTP_UPDATE_CMD = "sudo ntpdate ntp.ubuntu.com"

--- a/aws_unix.go
+++ b/aws_unix.go
@@ -1,0 +1,5 @@
+// +build !darwin
+
+package kr
+
+const NTP_UPDATE_CMD = "sudo ntpdate pool.ntp.org"

--- a/kr/kr_freebsd.go
+++ b/kr/kr_freebsd.go
@@ -1,1 +1,0 @@
-kr_linux.go

--- a/kr/kr_unix.go
+++ b/kr/kr_unix.go
@@ -1,3 +1,5 @@
+// +build !darwin
+
 package main
 
 import (

--- a/krd/bluetooth_freebsd.go
+++ b/krd/bluetooth_freebsd.go
@@ -1,1 +1,0 @@
-bluetooth_linux.go

--- a/krd/bluetooth_none.go
+++ b/krd/bluetooth_none.go
@@ -1,4 +1,4 @@
-// +build nobluetooth
+// +build nobluetooth !linux,!darwin
 
 package krd
 

--- a/machine_name_freebsd.go
+++ b/machine_name_freebsd.go
@@ -1,1 +1,0 @@
-machine_name_linux.go

--- a/machine_name_unix.go
+++ b/machine_name_unix.go
@@ -1,3 +1,5 @@
+// +build !darwin
+
 package kr
 
 import (

--- a/socket_freebsd.go
+++ b/socket_freebsd.go
@@ -1,1 +1,0 @@
-socket_linux.go

--- a/socket_unix.go
+++ b/socket_unix.go
@@ -1,3 +1,5 @@
+// +build !darwin
+
 package kr
 
 import (

--- a/version_freebsd.go
+++ b/version_freebsd.go
@@ -1,1 +1,0 @@
-version_linux.go

--- a/version_unix.go
+++ b/version_unix.go
@@ -1,3 +1,5 @@
+// +build !darwin
+
 package kr
 
 import (


### PR DESCRIPTION
- Use `freebsd-version` on FreeBSD;
- Replace the symlinks with [build constraints](http://blog.ralch.com/tutorial/golang-conditional-compilation/) specifying "not Mac" or "not Mac/Linux".