### PR TITLE
Declare GPG_TTY in login shells only on Mac.

### DIFF
--- a/kr/kr_pgp.go
+++ b/kr/kr_pgp.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"time"
 
@@ -186,9 +187,10 @@ func shellRCFileAndGPG_TTYExport() (file string, export string) {
 	fishConfig := filepath.Join(home, ".config", "fish", "config.fish")
 	if strings.Contains(shell, "zsh") {
 		return zshrc, "export GPG_TTY=$(tty)"
-	} else if strings.Contains(shell, "bash") && exists(bashProfile) {
+		// On MacOS, most terminal sessions are login shells, so use bash_profile
+	} else if strings.Contains(shell, "bash") && strings.Contains(runtime.GOOS, "darwin") && exists(bashProfile) {
 		return bashProfile, "export GPG_TTY=$(tty)"
-	} else if strings.Contains(shell, "bash") && exists(bashLogin) {
+	} else if strings.Contains(shell, "bash") && strings.Contains(runtime.GOOS, "darwin") && exists(bashLogin) {
 		return bashLogin, "export GPG_TTY=$(tty)"
 	} else if strings.Contains(shell, "bash") && exists(bashRc) {
 		return bashRc, "export GPG_TTY=$(tty)"


### PR DESCRIPTION
Closes #177. MacOS uses login shells for most interactive sessions.
Insert the necessary GPG_TTY declaration into bash_profile/login only on
Mac; all other platforms use .bashrc.

I agree to license all rights to my contributions in each modified file exclusively to KryptCo, Inc.