### PR TITLE
Include git [include]s when reading global git user ID

### DIFF
--- a/git.go
+++ b/git.go
@@ -12,11 +12,11 @@ func GlobalGitUserId() (id string, err error) {
 	if !strings.Contains(oldPath, "/usr/local/bin") || !strings.Contains(oldPath, "/usr/bin") {
 		os.Setenv("PATH", "/usr/bin:/usr/local/bin:"+oldPath)
 	}
-	name, err := exec.Command("git", "config", "--global", "user.name").Output()
+	name, err := exec.Command("git", "config", "--global", "--includes", "user.name").Output()
 	if err != nil {
 		return
 	}
-	email, err := exec.Command("git", "config", "--global", "user.email").Output()
+	email, err := exec.Command("git", "config", "--global", "--includes", "user.email").Output()
 	if err != nil {
 		return
 	}


### PR DESCRIPTION
Hello!

As of [git 1.7.10 (Feb 2012)](https://github.com/gitster/git/commit/9b25a0b52e09400719366f0a33d0d0da98bbf7b0), `~/.gitconfig` supports [include directives](https://git-scm.com/docs/git-config#_includes). However, when an option like `--global` is passed to `git config`, it ignores includes [unless told otherwise with the `--includes` flag](https://git-scm.com/docs/git-config#git-config---no-includes). It seems sensible for kr to include any includes when looking for the global git identity.

Sample use case: you have a global gitconfig shared among multiple machines, but want to use a different global identity (name/email) on each one, so you use an `[include]` in your `~/.gitconfig`.

Caveats:
- this would probably throw a flag-not-recognized error on old git -- I'm not sure if kr has minimum supported git versions, but error handling for this should be simple enough

---

I agree to license all rights to my contributions in each modified file exclusively to KryptCo, Inc.