### PR TITLE
pkcs11: Cast directly to target types for improved 32-bit support

### DIFF
--- a/pkcs11shim/src/pkcs11shim.rs
+++ b/pkcs11shim/src/pkcs11shim.rs
@@ -256,7 +256,7 @@ pub extern "C" fn CK_C_OpenSession(slotID: CK_SLOT_ID,
         return CKR_SESSION_PARALLEL_NOT_SUPPORTED;
     }
     unsafe {
-        *session = next_session_handle.fetch_add(1usize, SeqCst) as u64;
+        *session = next_session_handle.fetch_add(1usize, SeqCst) as CK_SESSION_HANDLE;
     }
     CKR_OK
 }

--- a/pkcs11shim/src/pkcs11shim.rs
+++ b/pkcs11shim/src/pkcs11shim.rs
@@ -197,7 +197,7 @@ pub extern "C" fn CK_C_GetMechanismList(slotID: CK_SLOT_ID,
     notice!("CK_C_GetMechanismList");
     if mechanism_list.is_null() {
         unsafe {
-            *count = MECHANISM_LIST.len() as u64;
+            *count = MECHANISM_LIST.len() as ::std::os::raw::c_ulong;
         }
         return CKR_OK;
     }


### PR DESCRIPTION
kr, krd, and krssh are both working on a Raspberry Pi 4 after these edits.

Resolves #89 