### PR TITLE
Windows support

### DIFF
--- a/.github/workflows/create_bins.yml
+++ b/.github/workflows/create_bins.yml
@@ -30,3 +30,32 @@ jobs:
       with:
         name: kr-${{ matrix.os }}.tar.gz
         path: kr-${{ matrix.os }}.tar.gz
+
+
+  buildwin:
+    name: Build Win
+    runs-on: windows-latest
+
+    steps:
+    - name: Set up Go 1.13
+      uses: actions/setup-go@v1
+      with:
+        go-version: 1.13
+      id: go
+
+    - name: Check out code into the Go module directory
+      uses: actions/checkout@v1
+
+    - name: build
+      run: build.bat
+      shell: cmd
+
+    - name: zip
+      run: Compress-Archive -Path bin\* -DestinationPath kr-windows-latest.zip
+      shell: powershell
+
+    - name: upload
+      uses: actions/upload-artifact@master
+      with:
+        name: kr-windows-latest.zip
+        path: kr-windows-latest.zip

--- a/build.bat
+++ b/build.bat
@@ -1,6 +1,6 @@
 mkdir bin
 cd src
-go.exe build -v -o ../bin/kr.exe ./kr
-go.exe build -v -o ../bin/krd.exe ./krd
-go.exe build -v -o ../bin/krssh.exe ./krssh
+go.exe build -v -trimpath -o ../bin/kr.exe ./kr
+go.exe build -v -trimpath -o ../bin/krd.exe ./krd
+go.exe build -v -trimpath -o ../bin/krssh.exe ./krssh
 cd ..

--- a/build.bat
+++ b/build.bat
@@ -1,0 +1,6 @@
+mkdir bin
+cd src
+go.exe build -v -o ../bin/kr.exe ./kr
+go.exe build -v -o ../bin/krd.exe ./krd
+go.exe build -v -o ../bin/krssh.exe ./krssh
+cd ..

--- a/src/common/analytics/analytics_ua_windows.go
+++ b/src/common/analytics/analytics_ua_windows.go
@@ -1,0 +1,26 @@
+package analytics
+
+import (
+	"fmt"
+	. "krypt.co/kr/common/version"
+	"sync"
+)
+
+// TODO
+var analytics_user_agent = fmt.Sprintf("Mozilla/5.0 (Windows NT 0.0; Win64; x64; rv: 0.0) (KHTML, like Gecko) Version/%s kr/%s", CURRENT_VERSION, CURRENT_VERSION)
+
+const analytics_os = "Linux"
+
+var cachedAnalyticsOSVersion *string
+var osVersionMutex sync.Mutex
+
+func getAnalyticsOSVersion() *string {
+	osVersionMutex.Lock()
+	defer osVersionMutex.Unlock()
+	if cachedAnalyticsOSVersion != nil {
+		return cachedAnalyticsOSVersion
+	}
+
+	// TODO
+	return nil
+}

--- a/src/common/analytics/analytics_ua_windows.go
+++ b/src/common/analytics/analytics_ua_windows.go
@@ -7,7 +7,7 @@ import (
 )
 
 // TODO
-var analytics_user_agent = fmt.Sprintf("User-Agent: Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Version/%s kr/%s", CURRENT_VERSION, CURRENT_VERSION)
+var analytics_user_agent = fmt.Sprintf("Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Version/%s kr/%s", CURRENT_VERSION, CURRENT_VERSION)
 
 const analytics_os = "Windows"
 
@@ -21,6 +21,7 @@ func getAnalyticsOSVersion() *string {
 		return cachedAnalyticsOSVersion
 	}
 
-	// TODO
-	return nil
+	//TODO: find system way to get version
+	// for now just use a constant here
+	return "WindowsOS"
 }

--- a/src/common/analytics/analytics_ua_windows.go
+++ b/src/common/analytics/analytics_ua_windows.go
@@ -7,9 +7,9 @@ import (
 )
 
 // TODO
-var analytics_user_agent = fmt.Sprintf("Mozilla/5.0 (Windows NT 0.0; Win64; x64; rv: 0.0) (KHTML, like Gecko) Version/%s kr/%s", CURRENT_VERSION, CURRENT_VERSION)
+var analytics_user_agent = fmt.Sprintf("User-Agent: Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Version/%s kr/%s", CURRENT_VERSION, CURRENT_VERSION)
 
-const analytics_os = "Linux"
+const analytics_os = "Windows"
 
 var cachedAnalyticsOSVersion *string
 var osVersionMutex sync.Mutex

--- a/src/common/log/logging_windows.go
+++ b/src/common/log/logging_windows.go
@@ -1,14 +1,11 @@
-// +build !windows
-
 package log
 
 import (
-	stdlog "log"
-	"log/syslog"
 	"os"
 
 	"github.com/op/go-logging"
-	socket "krypt.co/kr/common/socket"
+
+	. "krypt.co/kr/common/socket"
 )
 
 var Log = logging.MustGetLogger("")
@@ -21,6 +18,7 @@ var stderrFormat = logging.MustStringFormatter(
 
 func SetupLogging(prefix string, defaultLogLevel logging.Level, trySyslog bool) *logging.Logger {
 	var backend logging.Backend
+	/*
 	if trySyslog {
 		var err error
 		backend, err = logging.NewSyslogBackendPriority(prefix, syslog.LOG_NOTICE)
@@ -35,6 +33,7 @@ func SetupLogging(prefix string, defaultLogLevel logging.Level, trySyslog bool) 
 		}
 
 	}
+	*/
 	if backend == nil {
 		var err error
 		var file *os.File
@@ -43,7 +42,7 @@ func SetupLogging(prefix string, defaultLogLevel logging.Level, trySyslog bool) 
 			logName = "kr"
 		}
 		logName += ".log"
-		path, err := socket.KrDirFile(logName)
+		path, err := KrDirFile(logName)
 		if err != nil {
 			file = os.Stderr
 		} else {

--- a/src/common/socket/socket.go
+++ b/src/common/socket/socket.go
@@ -80,7 +80,7 @@ func KrDirFile(file string) (fullPath string, err error) {
 
 const AGENT_SOCKET_FILENAME = "krd-agent.sock"
 
-func AgentListen() (listener net.Listener, err error) {
+func AgentListenUnix() (listener net.Listener, err error) {
 	socketPath, err := KrDirFile(AGENT_SOCKET_FILENAME)
 	if err != nil {
 		return
@@ -176,9 +176,4 @@ func DaemonSocketOrFatal() (unixFile string) {
 		log.Fatal("Could not open connection to daemon. Make sure it is running by typing \"kr restart\".")
 	}
 	return
-}
-
-func IsKrdRunning() bool {
-	err := exec.Command("pgrep", "-U", User(), "krd").Run()
-	return nil == err
 }

--- a/src/common/socket/socket_darwin.go
+++ b/src/common/socket/socket_darwin.go
@@ -12,3 +12,12 @@ func DaemonDial(unixFile string) (conn net.Conn, err error) {
 	}
 	return
 }
+
+func IsKrdRunning() bool {
+	err := exec.Command("pgrep", "-U", User(), "krd").Run()
+	return nil == err
+}
+
+func AgentListen() (listener net.Listener, err error) {
+	return AgentListenUnix()
+}

--- a/src/common/socket/socket_darwin.go
+++ b/src/common/socket/socket_darwin.go
@@ -3,6 +3,7 @@ package socket
 import (
 	"fmt"
 	"net"
+	"os/exec"
 )
 
 func DaemonDial(unixFile string) (conn net.Conn, err error) {

--- a/src/common/socket/socket_unix.go
+++ b/src/common/socket/socket_unix.go
@@ -1,4 +1,4 @@
-// +build !darwin
+// +build !darwin,!windows
 
 package socket
 
@@ -36,4 +36,13 @@ func DaemonDial(unixFile string) (conn net.Conn, err error) {
 func KillKrd() {
 	exec.Command("pkill", "-U", User(), "-x", "krd").Run()
 	<-time.After(1*time.Second)
+}
+
+func IsKrdRunning() bool {
+	err := exec.Command("pgrep", "-U", User(), "krd").Run()
+	return nil == err
+}
+
+func AgentListen() (listener net.Listener, err error) {
+	return AgentListenUnix()
 }

--- a/src/common/socket/socket_windows.go
+++ b/src/common/socket/socket_windows.go
@@ -1,0 +1,58 @@
+// +build windows
+
+package socket
+
+import (
+	"bytes"
+	"fmt"
+	"github.com/Microsoft/go-winio"
+	"krypt.co/kr/common/util"
+	"net"
+	"os"
+	"os/exec"
+	"time"
+)
+
+const AGENT_PIPE = "\\\\.\\pipe\\krd-agent"
+
+func AgentListen() (listener net.Listener, err error) {
+	listener, err = winio.ListenPipe(AGENT_PIPE, nil)
+	return
+}
+
+func DaemonDial(unixFile string) (conn net.Conn, err error) {
+	if !IsKrdRunning() {
+		os.Stderr.WriteString(util.Yellow("Krypton ▶ Restarting krd...\r\n"))
+		_ = exec.Command("cmd.exe", "/C", "start", "/b", `krd.exe`).Start()
+		<-time.After(1 * time.Second)
+	}
+	conn, err = net.Dial("unix", unixFile)
+	/*
+	TODO
+	if err != nil {
+		//	restart then try again
+		os.Stderr.WriteString(Yellow("Krypton ▶ Restarting krd...\r\n"))
+		KillKrd()
+		exec.Command("nohup", "krd").Start()
+		<-time.After(1 * time.Second)
+		conn, err = net.Dial("unix", unixFile)
+	}
+	 */
+	if err != nil {
+		err = fmt.Errorf("Failed to connect to Krypton daemon. Please make sure it is running by typing \"kr restart\".")
+	}
+	return
+}
+
+func KillKrd() {
+	_ = exec.Command("taskkill", "/F", "/FI", `USERNAME eq ` + User(), "/IM", "krd.exe").Run()
+	<-time.After(1*time.Second)
+}
+
+func IsKrdRunning() bool {
+	cmd := exec.Command("tasklist", "/FI", `USERNAME eq ` + User(), "/FI", `IMAGENAME eq krd.exe`)
+	if ret, err := cmd.CombinedOutput(); err == nil {
+		return bytes.Contains(ret, []byte("krd.exe"))
+	}
+	return false
+}

--- a/src/common/socket/socket_windows.go
+++ b/src/common/socket/socket_windows.go
@@ -37,7 +37,7 @@ func DaemonDial(unixFile string) (conn net.Conn, err error) {
 		if pfx, err := getPrefix(); err == nil {
 			exe = pfx + `\krd.exe`
 		}
-		_ = exec.Command("cmd.exe", "/C", "start", "/b", exe).Start()
+		_ = exec.Command(exe).Start()
 		<-time.After(1 * time.Second)
 	}
 	conn, err = net.Dial("unix", unixFile)

--- a/src/daemon/enclave/enclave.go
+++ b/src/daemon/enclave/enclave.go
@@ -1,7 +1,7 @@
 package enclave
 
 /*
-*	Facillitates communication with a mobile phone SSH key enclave.
+*	Facilitates communication with a mobile phone SSH key enclave.
  */
 
 import (

--- a/src/daemon/ssh_agent.go
+++ b/src/daemon/ssh_agent.go
@@ -9,7 +9,6 @@ import (
 	"fmt"
 	"krypt.co/kr/common/socket"
 	"net"
-	"os"
 	"strings"
 	"sync"
 	"time"
@@ -34,11 +33,10 @@ type sessionIDSig struct {
 type hostAuthCallback chan *HostAuth
 
 func (a *Agent) withOriginalAgent(do func(agent.Agent)) error {
-	originalAgentSock := os.Getenv("SSH_AUTH_SOCK")
-	if strings.HasSuffix(originalAgentSock, "krd-agent.sock") {
+	conn, err := getOriginalAgentConn()
+	if conn == nil {
 		return nil
 	}
-	conn, err := net.Dial("unix", originalAgentSock)
 	if err != nil {
 		a.log.Error("error connecting to fallbackAgent: " + err.Error())
 		return err

--- a/src/daemon/ssh_agent_unix.go
+++ b/src/daemon/ssh_agent_unix.go
@@ -1,0 +1,18 @@
+// +build !windows
+
+package daemon
+
+import (
+	"net"
+	"os"
+	"strings"
+)
+
+func getOriginalAgentConn() (net.Conn, error) {
+	originalAgentSock := os.Getenv("SSH_AUTH_SOCK")
+	if strings.HasSuffix(originalAgentSock, "krd-agent.sock") {
+		return nil, nil
+	}
+
+	return net.Dial("unix", originalAgentSock)
+}

--- a/src/daemon/ssh_agent_windows.go
+++ b/src/daemon/ssh_agent_windows.go
@@ -1,0 +1,17 @@
+package daemon
+
+import (
+	"github.com/Microsoft/go-winio"
+	"net"
+	"os"
+	"strings"
+)
+
+func getOriginalAgentConn() (net.Conn, error) {
+	originalAgentSock := os.Getenv("SSH_AUTH_SOCK")
+	if strings.HasSuffix(originalAgentSock, "krd-agent") {
+		return nil, nil
+	}
+
+	return winio.DialPipe(`\\.\pipe\openssh-ssh-agent`, nil)
+}

--- a/src/daemon/sshconfig.go
+++ b/src/daemon/sshconfig.go
@@ -4,6 +4,8 @@ import (
 	"bytes"
 	"io/ioutil"
 	"os"
+
+	. "krypt.co/kr/common/socket"
 )
 
 func replaceKryptoniteWithKrypton(in []byte) []byte {
@@ -13,7 +15,7 @@ func replaceKryptoniteWithKrypton(in []byte) []byte {
 }
 
 func UpgradeSSHConfig() (err error) {
-	sshDirPath := os.Getenv("HOME") + "/.ssh"
+	sshDirPath := HomeDir() + "/.ssh"
 	_ = os.MkdirAll(sshDirPath, 0700)
 	sshConfigPath := sshDirPath + "/config"
 

--- a/src/go.mod
+++ b/src/go.mod
@@ -3,6 +3,7 @@ module krypt.co/kr
 go 1.13
 
 require (
+	github.com/Microsoft/go-winio v0.4.14
 	github.com/atotto/clipboard v0.1.2
 	github.com/aws/aws-sdk-go v1.25.15
 	github.com/blang/semver v3.5.1+incompatible
@@ -17,10 +18,12 @@ require (
 	github.com/mattn/go-isatty v0.0.10 // indirect
 	github.com/op/go-logging v0.0.0-20160315200505-970db520ece7
 	github.com/paypal/gatt v0.0.0-20151011220935-4ae819d591cf // indirect
+	github.com/pkg/browser v0.0.0-20180916011732-0a3d74bf9ce4
 	github.com/satori/go.uuid v1.2.0
 	github.com/urfave/cli v1.22.1
 	github.com/youtube/vitess v2.1.1+incompatible
 	golang.org/x/crypto v0.0.0-20191011191535-87dc89f01550
+	golang.org/x/sys v0.0.0-20191008105621-543471e840be
 )
 
 replace golang.org/x/crypto v0.0.0-20191011191535-87dc89f01550 => github.com/kryptco/go-crypto v0.0.0-20191020215841-c5850b359d8a

--- a/src/go.sum
+++ b/src/go.sum
@@ -1,4 +1,6 @@
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
+github.com/Microsoft/go-winio v0.4.14 h1:+hMXMk01us9KgxGb7ftKQt2Xpf5hH/yky+TDA+qxleU=
+github.com/Microsoft/go-winio v0.4.14/go.mod h1:qXqCSQ3Xa7+6tgxaGTIe4Kpcdsi+P8jBhyzoq1bpyYA=
 github.com/atotto/clipboard v0.1.2 h1:YZCtFu5Ie8qX2VmVTBnrqLSiU9XOWwqNRmdT3gIQzbY=
 github.com/atotto/clipboard v0.1.2/go.mod h1:ZY9tmq7sm5xIbd9bOK4onWV4S6X0u6GY7Vn0Yu86PYI=
 github.com/aws/aws-sdk-go v1.25.15 h1:2XrAm3F7QuNguJXJ6SUJxywL1TPNDM3z/mNEaS0CHtk=
@@ -7,6 +9,7 @@ github.com/blang/semver v3.5.1+incompatible h1:cQNTCjp13qL8KC3Nbxr/y2Bqb63oX6wdn
 github.com/blang/semver v3.5.1+incompatible/go.mod h1:kRBLl5iJ+tD4TcOOxsy/0fnwebNt5EWlYSAyrTnjyyk=
 github.com/cpuguy83/go-md2man/v2 v2.0.0-20190314233015-f79a8a8ca69d h1:U+s90UTSYgptZMwQh2aRr3LuazLJIa+Pg3Kc1ylSYVY=
 github.com/cpuguy83/go-md2man/v2 v2.0.0-20190314233015-f79a8a8ca69d/go.mod h1:maD7wRr/U5Z6m/iR4s+kqSMx2CaBsrgA7czyZG/E6dU=
+github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/fatih/color v1.7.0 h1:DkWD4oS2D8LGGgTQ6IvwJJXSL5Vp2ffcQg58nFV38Ys=
 github.com/fatih/color v1.7.0/go.mod h1:Zm6kSWBoL9eyXnKyktHP6abPY2pDugNf5KwzbycvMj4=
 github.com/golang/groupcache v0.0.0-20191002201903-404acd9df4cc h1:55rEp52jU6bkyslZ1+C/7NGfpQsEc6pxGLAGDOctqbw=
@@ -17,6 +20,7 @@ github.com/jmespath/go-jmespath v0.0.0-20180206201540-c2b33e8439af h1:pmfjZENx5i
 github.com/jmespath/go-jmespath v0.0.0-20180206201540-c2b33e8439af/go.mod h1:Nht3zPeWKUH0NzdCt2Blrr5ys8VGpn0CEB0cQHVjt7k=
 github.com/keybase/saltpack v0.0.0-20190828020936-3f47e8e2e6ec h1:ejQ18jEAjyiFen49m7h8x46kzC3heD/HbUiOPzBLVWg=
 github.com/keybase/saltpack v0.0.0-20190828020936-3f47e8e2e6ec/go.mod h1:loEJH62iafRcA8ZYlUEq9WgJh/Z9BHdHHfAmxzacQng=
+github.com/konsorten/go-windows-terminal-sequences v1.0.1/go.mod h1:T0+1ngSBFLxvqU3pZ+m/2kptfBszLMUkC4ZK/EgS/cQ=
 github.com/kryptco/gf256 v0.0.0-20160413180133-bbd714a0764d h1:oDNL85JcK6Ex87EMV/BUzUD6gCTUos0BxmOh+asxvSI=
 github.com/kryptco/gf256 v0.0.0-20160413180133-bbd714a0764d/go.mod h1:ISD7LkDBEju/eoUn4vtV/WgGAbM/k4wlJneRmsTXA2I=
 github.com/kryptco/go-crypto v0.0.0-20191011191535-87dc89f01550/go.mod h1:yigFU9vqHzYiE8UmvKecakEJjdnWj3jj499lnFckfCI=
@@ -35,6 +39,9 @@ github.com/op/go-logging v0.0.0-20160315200505-970db520ece7 h1:lDH9UUVJtmYCjyT0C
 github.com/op/go-logging v0.0.0-20160315200505-970db520ece7/go.mod h1:HzydrMdWErDVzsI23lYNej1Htcns9BCg93Dk0bBINWk=
 github.com/paypal/gatt v0.0.0-20151011220935-4ae819d591cf h1:RHRtrMle1AlWsMdCoIQIbq7IB2y8/5qEsUoAzjCCSCw=
 github.com/paypal/gatt v0.0.0-20151011220935-4ae819d591cf/go.mod h1:+AwQL2mK3Pd3S+TUwg0tYQjid0q1txyNUJuuSmz8Kdk=
+github.com/pkg/browser v0.0.0-20180916011732-0a3d74bf9ce4 h1:49lOXmGaUpV9Fz3gd7TFZY106KVlPVa5jcYD1gaQf98=
+github.com/pkg/browser v0.0.0-20180916011732-0a3d74bf9ce4/go.mod h1:4OwLy04Bl9Ef3GJJCoec+30X3LQs/0/m4HFRt/2LUSA=
+github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/russross/blackfriday/v2 v2.0.1 h1:lPqVAte+HuHNfhJ/0LC98ESWRz8afy9tM/0RK8m9o+Q=
 github.com/russross/blackfriday/v2 v2.0.1/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
@@ -42,6 +49,9 @@ github.com/satori/go.uuid v1.2.0 h1:0uYX9dsZ2yD7q2RtLRtPSdGDWzjeM3TbMJP9utgA0ww=
 github.com/satori/go.uuid v1.2.0/go.mod h1:dA0hQrYB0VpLJoorglMZABFdXlWrHn1NEOzdhQKdks0=
 github.com/shurcooL/sanitized_anchor_name v1.0.0 h1:PdmoCO6wvbs+7yrJyMORt4/BmY5IYyJwS/kOiWx8mHo=
 github.com/shurcooL/sanitized_anchor_name v1.0.0/go.mod h1:1NzhyTcUVG4SuEtjjoZeVRXNmyL/1OwPU0+IJeTBvfc=
+github.com/sirupsen/logrus v1.4.1/go.mod h1:ni0Sbl8bgC9z8RoU9G6nDWqqs/fq4eDPysMBDgk/93Q=
+github.com/stretchr/objx v0.1.1/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
+github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
 github.com/urfave/cli v1.22.1 h1:+mkCCcOFKPnCmVYVcURKps1Xe+3zP90gSYGNfRkjoIY=
 github.com/urfave/cli v1.22.1/go.mod h1:Gos4lmkARVdJ6EkW0WaNv/tZAAMe9V7XWyB60NtXRu0=
 github.com/youtube/vitess v2.1.1+incompatible h1:SE+P7DNX/jw5RHFs5CHRhZQjq402EJFCD33JhzQMdDw=
@@ -50,9 +60,11 @@ golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACk
 golang.org/x/crypto v0.0.0-20191011191535-87dc89f01550 h1:ObdrDkeb4kJdCP557AjRjq69pTHfNouLtWZG7j9rPN8=
 golang.org/x/crypto v0.0.0-20191011191535-87dc89f01550/go.mod h1:yigFU9vqHzYiE8UmvKecakEJjdnWj3jj499lnFckfCI=
 golang.org/x/net v0.0.0-20190404232315-eb5bcb51f2a3/go.mod h1:t9HGtf8HONx5eT2rtn7q6eTqICYqUVnKs3thJo3Qplg=
+golang.org/x/sys v0.0.0-20180905080454-ebe1bf3edb33/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20190215142949-d0b11bdaac8a/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20190222072716-a9d3bda3a223/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20190412213103-97732733099d/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20190507160741-ecd444e8653b/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20191008105621-543471e840be h1:QAcqgptGM8IQBC9K/RC4o+O9YmqEm0diQn9QmZw/0mU=
 golang.org/x/sys v0.0.0-20191008105621-543471e840be/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=

--- a/src/kr/kr.go
+++ b/src/kr/kr.go
@@ -523,6 +523,7 @@ func restartCommand(c *cli.Context) (err error) {
 }
 
 func main() {
+	initTerminal()
 	app := cli.NewApp()
 	app.Name = "kr"
 	app.Usage = "communicate with Krypton and krd - the Krypton daemon"

--- a/src/kr/kr_darwin.go
+++ b/src/kr/kr_darwin.go
@@ -37,6 +37,9 @@ const PLIST_TEMPLATE = `<?xml version="1.0" encoding="UTF-8"?>
 </dict>
 </plist>`
 
+func initTerminal() {
+}
+
 func copyPlist() (err error) {
 	output, err := exec.Command("which", "krd").Output()
 	if err != nil {

--- a/src/kr/kr_unix.go
+++ b/src/kr/kr_unix.go
@@ -1,4 +1,4 @@
-// +build !darwin
+// +build !darwin,!windows
 
 package main
 
@@ -10,6 +10,9 @@ import (
 	. "krypt.co/kr/common/analytics"
 	. "krypt.co/kr/common/socket"
 )
+
+func initTerminal() {
+}
 
 func restartCommandOptions(c *cli.Context, isUserInitiated bool) (err error) {
 	if isUserInitiated {

--- a/src/kr/kr_windows.go
+++ b/src/kr/kr_windows.go
@@ -60,7 +60,7 @@ func startKrd() (err error) {
 	if pfx, err := getPrefix(); err == nil {
 		exe = pfx + `\krd.exe`
 	}
-	cmd := exec.Command("cmd.exe", "/C", "start", "/b", exe)
+	cmd := exec.Command(exe)
 	return cmd.Run()
 }
 

--- a/src/kr/kr_windows.go
+++ b/src/kr/kr_windows.go
@@ -56,7 +56,11 @@ func uninstallCommand(c *cli.Context) (err error) {
 }
 
 func startKrd() (err error) {
-	cmd := exec.Command("cmd.exe", "/C", "start", "/b", `krd.exe`)
+	exe := "krd.exe"
+	if pfx, err := getPrefix(); err == nil {
+		exe = pfx + `\krd.exe`
+	}
+	cmd := exec.Command("cmd.exe", "/C", "start", "/b", exe)
 	return cmd.Run()
 }
 

--- a/src/kr/kr_windows.go
+++ b/src/kr/kr_windows.go
@@ -1,0 +1,72 @@
+// +build windows
+
+package main
+
+import (
+	"fmt"
+	"github.com/pkg/browser"
+	"github.com/urfave/cli"
+	"golang.org/x/sys/windows"
+	"os"
+	"os/exec"
+
+	. "krypt.co/kr/common/analytics"
+	. "krypt.co/kr/common/socket"
+)
+
+func initTerminal() {
+	var m uint32
+	windows.GetConsoleMode(windows.Stdout, &m)
+	windows.SetConsoleMode(windows.Stdout, m|windows.ENABLE_VIRTUAL_TERMINAL_PROCESSING)
+}
+
+func restartCommandOptions(c *cli.Context, isUserInitiated bool) (err error) {
+	if isUserInitiated {
+		Analytics{}.PostEventUsingPersistedTrackingID("kr", "restart", nil, nil)
+	}
+
+	_ = migrateSSHConfig()
+
+	KillKrd()
+	startKrd()
+
+	if isUserInitiated {
+		PrintErr(os.Stderr, "Restarted Krypton daemon.")
+	}
+	return
+}
+
+func upgradeCommand(c *cli.Context) (err error) {
+	return fmt.Errorf("Upgrade not supported")
+}
+
+func uninstallCommand(c *cli.Context) (err error) {
+	go func() {
+		Analytics{}.PostEventUsingPersistedTrackingID("kr", "uninstall", nil, nil)
+	}()
+	confirmOrFatal(os.Stderr, "Uninstall Krypton from this workstation?")
+
+	cleanSSHConfig()
+
+	KillKrd()
+
+	//uninstallCodesigning()
+	PrintErr(os.Stderr, "Krypton uninstalled. If you experience any issues, please refer to https://krypt.co/docs/start/installation.html#uninstalling-kr")
+	return
+}
+
+func startKrd() (err error) {
+	cmd := exec.Command("cmd.exe", "/C", "start", "/b", `krd.exe`)
+	return cmd.Run()
+}
+
+func openBrowser(url string) {
+	err := browser.OpenURL(url)
+	if err != nil {
+		os.Stderr.WriteString("Unable to open browser, please visit " + url + "\r\n")
+	}
+}
+
+func killKrd() {
+	KillKrd()
+}

--- a/src/kr/kr_windows.go
+++ b/src/kr/kr_windows.go
@@ -61,7 +61,7 @@ func startKrd() (err error) {
 		exe = pfx + `\krd.exe`
 	}
 	cmd := exec.Command(exe)
-	return cmd.Run()
+	return cmd.Start()
 }
 
 func openBrowser(url string) {

--- a/src/kr/sshconfig.go
+++ b/src/kr/sshconfig.go
@@ -40,7 +40,7 @@ Host *
 const SSH_CONFIG_FORMAT_WIN = `# Added by Krypton
 Host *
 	IdentityAgent \\.\pipe\krd-agent
-	ProxyCommand %s\krssh.exe %%h %%p`
+	ProxyCommand "%s\krssh.exe" %%h %%p`
 /*
 	IdentityFile ~/.ssh/id_krypton
 	IdentityFile ~/.ssh/id_ed25519

--- a/src/kr/sshconfig.go
+++ b/src/kr/sshconfig.go
@@ -40,7 +40,7 @@ Host *
 const SSH_CONFIG_FORMAT_WIN = `# Added by Krypton
 Host *
 	IdentityAgent \\.\pipe\krd-agent
-	ProxyCommand "%s\krssh.exe" %%h %%p`
+	ProxyCommand %s\krssh.exe %%h %%p`
 /*
 	IdentityFile ~/.ssh/id_krypton
 	IdentityFile ~/.ssh/id_ed25519

--- a/src/kr/sshconfig_unix.go
+++ b/src/kr/sshconfig_unix.go
@@ -1,0 +1,18 @@
+// +build !windows
+
+package main
+
+import (
+	"os"
+	"os/exec"
+	"strings"
+)
+
+func getPrefix() (string, error) {
+	krAbsPath, err := exec.Command("which", "kr").Output()
+	if err != nil {
+		PrintErr(os.Stderr, kr.Red("Krypton ▶ Could not find kr on PATH"))
+		return "", err
+	}
+	return strings.TrimSuffix(strings.TrimSpace(string(krAbsPath)), "/bin/kr"), nil
+}

--- a/src/kr/sshconfig_unix.go
+++ b/src/kr/sshconfig_unix.go
@@ -6,12 +6,14 @@ import (
 	"os"
 	"os/exec"
 	"strings"
+
+	. "krypt.co/kr/common/util"
 )
 
 func getPrefix() (string, error) {
 	krAbsPath, err := exec.Command("which", "kr").Output()
 	if err != nil {
-		PrintErr(os.Stderr, kr.Red("Krypton ▶ Could not find kr on PATH"))
+		PrintErr(os.Stderr, Red("Krypton ▶ Could not find kr on PATH"))
 		return "", err
 	}
 	return strings.TrimSuffix(strings.TrimSpace(string(krAbsPath)), "/bin/kr"), nil

--- a/src/kr/sshconfig_windows.go
+++ b/src/kr/sshconfig_windows.go
@@ -1,0 +1,17 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+
+	. "krypt.co/kr/common/util"
+)
+
+func getPrefix() (string, error) {
+	if ex, err := os.Executable(); err == nil {
+		return filepath.Dir(ex), nil
+	} else {
+		PrintErr(os.Stderr, Red("Krypton ▶ Problem getting path of kr.exe"))
+		return "", err
+	}
+}


### PR DESCRIPTION
Ported as much as possible to windows. Works still under the same principles and needs (OpenSSH_for_Windows_7.7p1). Uses ProxyCommand, moved ssh agent to windows pipe.
Compiled files here: https://github.com/zobo/kr/releases/tag/2.4.15-win

One big caveat is that the vendored code is quite old and the ssh agent has problems connecting to newer servers as it does not pass ssh flags with it.

I tried to go.mod the code but turned out to be a challenge due to some vendored packages not being available anymore.