### PR TITLE
Remove SSH config when unpairing

### DIFF
--- a/src/kr/kr.go
+++ b/src/kr/kr.go
@@ -253,6 +253,14 @@ func unpairOver(unixFile string, stdout io.ReadWriter, stderr io.ReadWriter) (er
 	default:
 		PrintFatal(stderr, "Unpair failed with error %d", response.StatusCode)
 	}
+
+	if os.Getenv(KR_SKIP_SSH_CONFIG) == "" {
+		err = cleanSSHConfig()
+		if err != nil {
+			PrintFatal(stderr, "Unpair failed to clean SSH config with error %s", err.Error())
+		}
+	}
+
 	stdout.Write([]byte("Unpaired Krypton.\r\n"))
 	return
 }

--- a/src/kr/kr_test.go
+++ b/src/kr/kr_test.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"bytes"
+	"io/ioutil"
 	"os"
 	"testing"
 
@@ -31,6 +32,15 @@ func testPairSuccess(t *testing.T, unixFile string, ec EnclaveClientI) {
 	}
 }
 
+func isSSHConfigEdited(t *testing.T) bool {
+	sshConfigPath, _ := getSSHConfigAndBakPaths()
+	currentConfigContents, err := ioutil.ReadFile(sshConfigPath)
+	if err != nil {
+		t.Fatal("failed to open SSH config", err)
+	}
+	return bytes.Contains(currentConfigContents, []byte(getKrSSHConfigBlockOrFatal()))
+}
+
 func TestUnpair(t *testing.T) {
 	ec, _, unixFile := NewLocalUnixServer(t)
 	defer os.Remove(unixFile)
@@ -39,13 +49,28 @@ func TestUnpair(t *testing.T) {
 
 	testPairSuccess(t, unixFile, ec)
 
+	// manually make call to edit SSH config since test util doesn't call full
+	// pair command which is normally responsible for modifying SSH config
+	err := os.Setenv("HOME", os.TempDir())
+	if err != nil {
+		t.Fatal("failed to override HOME env var to create test SSH config")
+	}
+	err = autoEditSSHConfig()
+	if err != nil {
+		t.Fatal("failed to create SSH config for test")
+	}
+
 	stdout := &bytes.Buffer{}
 	stderr := &bytes.Buffer{}
-	err := unpairOver(unixFile, stdout, stderr)
+	err = unpairOver(unixFile, stdout, stderr)
+
 	if err != nil {
 		t.Fatal(err)
 	}
 	if ec.IsPaired() {
 		t.Fatal("paired")
+	}
+	if isSSHConfigEdited(t) {
+		t.Fatal("failed to reset SSH config after unpairing")
 	}
 }


### PR DESCRIPTION
Hello Krypton folks,

Wanted to PR in a feature to remove the SSH config changes `kr` makes during the `pair` command. Motivation is to support shared machines with `kr` installed whose users are not all entirely using `kr`(i.e. when pair-programming with someone who does not want to use `kr`)

Given that the `pair` command always attempts to modify SSH config as `kr` desires, I figured it should be fine to remove the config on `unpair` command. This proposed change prevents modification to SSH config if opting out via the `KR_SKIP_SSH_CONFIG` env var. 

Test I modified to drive out development isn't the cleanest I understand; however, I didn't want to make big refactoring decisions for those tests without some input from y'all first on whether or not this feature is something you'd be fine introducing. Would still of course love to hear any feedback and of course if there is any issue with this! 

Thanks,
Jwal